### PR TITLE
feat: Support for AWS Temporal Credentials Authentication via AWS_SESSION_TOKEN env variable

### DIFF
--- a/.github/workflows/ngx-aws-deploy-s3.yml
+++ b/.github/workflows/ngx-aws-deploy-s3.yml
@@ -1,0 +1,50 @@
+name: ngx-aws-deploy-s3
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x]
+    
+    env:
+      NX_BRANCH: ${{ github.event.number }}
+      NX_RUN_GROUP: ${{ github.run_id }}
+    
+    steps:
+      - name: Clone repository
+        # `fetch-depth` defaults to 1.
+        uses: actions/checkout@v2
+      - name: Cache builder node modules
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-${{ matrix.version }}
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.version }}
+      - name: Install Builder Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Symlink dist 🔗
+        run: npm run symlinks
+      - name: Test Upload S3
+        run: ng deploy
+        env:
+          NG_DEPLOY_AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_id}}
+          NG_DEPLOY_AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_access_key }}
+          NG_DEPLOY_AWS_BUCKET: ngx-aws-deploy-test
+          NG_DEPLOY_AWS_REGION: us-east-1
+          NG_CLI_ANALYTICS: false
+

--- a/.github/workflows/ngx-aws-deploy-s3.yml
+++ b/.github/workflows/ngx-aws-deploy-s3.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm ci
       - name: Symlink dist 🔗
         run: npm run symlinks
+      - name: Build
+        run: npm run nx run-many -- --target=build --all --parallel=true --with-deps=true --prod
       - name: Test Upload S3
         run: npm run test-deploy
         env:

--- a/.github/workflows/ngx-aws-deploy-s3.yml
+++ b/.github/workflows/ngx-aws-deploy-s3.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Symlink dist 🔗
         run: npm run symlinks
       - name: Test Upload S3
-        run: ng deploy
+        run: npm run test-deploy
         env:
           NG_DEPLOY_AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_id}}
           NG_DEPLOY_AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_access_key }}

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npx cross-env NG_DEPLOY_AWS_ACCESS_KEY_ID=1234 NG_DEPLOY_AWS_SECRET_ACCESS_KEY=3
 Keep in mind that **with the default config, everybody that has access to the angular.json will have your aws secret**.
 If you want more security, you can also use environment variable with `NG_DEPLOY_AWS_ACCESS_KEY_ID`, `NG_DEPLOY_AWS_SECRET_ACCESS_KEY`, `NG_DEPLOY_AWS_BUCKET` and `NG_DEPLOY_AWS_REGION`.
 
-### Minimal Required IAM Policy for AWS Credentials
+#### Minimal Required IAM Policy for AWS Credentials
 ```
 {
     "Version": "2012-10-17",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ npx cross-env NG_DEPLOY_AWS_ACCESS_KEY_ID=1234 NG_DEPLOY_AWS_SECRET_ACCESS_KEY=3
 Keep in mind that **with the default config, everybody that has access to the angular.json will have your aws secret**.
 If you want more security, you can also use environment variable with `NG_DEPLOY_AWS_ACCESS_KEY_ID`, `NG_DEPLOY_AWS_SECRET_ACCESS_KEY`, `NG_DEPLOY_AWS_BUCKET` and `NG_DEPLOY_AWS_REGION`.
 
+### Minimal Required IAM Policy for AWS Credentials
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::$BUCKET_NAME$"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::$BUCKET_NAME$/*"
+            ]
+        }
+    ]
+}
+```
+
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/libs/ngx-aws-deploy/src/lib/deploy/config.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/config.ts
@@ -8,6 +8,10 @@ export const getSecretAccessKey = (): string => {
   return process.env.NG_DEPLOY_AWS_SECRET_ACCESS_KEY as string || process.env.AWS_SECRET_ACCESS_KEY as string;
 };
 
+export const getSessionToken = (): string => {
+  return process.env.NG_DEPLOY_AWS_SESSION_TOKEN as string || process.env.AWS_SESSION_TOKEN as string;
+};
+
 export const getBucket = (builderConfig: Schema): string => {
   return process.env.NG_DEPLOY_AWS_BUCKET || (builderConfig.bucket as string);
 };

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -13,7 +13,6 @@ import {
   getSessionToken,
   getSubFolder,
 } from './config';
-import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 
 export class Uploader {
   private _context: BuilderContext;

--- a/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
+++ b/libs/ngx-aws-deploy/src/lib/deploy/uploader.ts
@@ -9,8 +9,11 @@ import {
   getAccessKeyId,
   getBucket,
   getRegion,
-  getSecretAccessKey, getSubFolder
+  getSecretAccessKey,
+  getSessionToken,
+  getSubFolder,
 } from './config';
+import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 
 export class Uploader {
   private _context: BuilderContext;
@@ -28,10 +31,14 @@ export class Uploader {
     this._subFolder = getSubFolder(this._builderConfig);
 
     AWS.config.update({ region: this._region });
+
     this._s3 = new AWS.S3({
       apiVersion: 'latest',
-      secretAccessKey: getSecretAccessKey(),
-      accessKeyId: getAccessKeyId(),
+      credentials: new AWS.Credentials({
+        secretAccessKey: getSecretAccessKey(),
+        accessKeyId: getAccessKeyId(),
+        sessionToken: getSessionToken()
+      })
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "@angular/platform-browser-dynamic": "12.0.0",
     "@angular/router": "12.0.0",
     "rxjs": "~6.5.5",
-    "zone.js": "~0.11.4",
-    "@jefiozie/ngx-aws-deploy": "file:./libs/ngx-aws-deploy"
+    "zone.js": "~0.11.4"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "ng test",
     "lint": "nx workspace-lint && ng lint",
     "e2e": "ng e2e",
+    "test-deploy": "ng deploy",
     "affected:apps": "nx affected:apps",
     "affected:libs": "nx affected:libs",
     "affected:build": "nx affected:build",
@@ -40,7 +41,8 @@
     "@angular/platform-browser-dynamic": "12.0.0",
     "@angular/router": "12.0.0",
     "rxjs": "~6.5.5",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4",
+    "@jefiozie/ngx-aws-deploy": "file:./libs/ngx-aws-deploy"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "12.0.0",


### PR DESCRIPTION
### AWS Temporal Credentials Support

Support for uploading files with Temporal AWS Credentials obtained using the [AWS STS Service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html).


### Usage sample:
```
export AWS_ACCESS_KEY_ID=%acceskey%
export AWS_SECRET_ACCESS_KEY=%secretKey%
export AWS_SESSION_TOKEN=%sessionToken%
```

or via Custom NG_DEPLOY variables: 
```
export NG_DEPLOY_AWS_ACCESS_KEY_ID=%acceskey%
export NG_DEPLOY_AWS_SECRET_ACCESS_KEY=%secretKey%
export NG_DEPLOY_AWS_SESSION_TOKEN=%sessionToken%
```


- Added Github Action for Testing actual deployment to S3
- Added S3 Minimal policy for IAM access